### PR TITLE
Ansible log parser rules from ansible-env-swisstxt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,3 +121,8 @@
   tags:
   - packages
   - jenkins-plugins
+
+- name: template log parsing rules
+  template:
+    src: ansible-log-parser-rules.txt.j2
+    dest: /var/lib/jenkins/ansible-log-parser-rules.txt

--- a/templates/ansible-log-parser-rules.txt.j2
+++ b/templates/ansible-log-parser-rules.txt.j2
@@ -1,5 +1,4 @@
 error /ERROR! the playbook: .* could not be found/
 error /failed=[1-9]/
 error /unreachable=[1-9]/
-error /fatal:(?!.*\n.*...ignoring)/
 warning /changed=[1-9]/

--- a/templates/ansible-log-parser-rules.txt.j2
+++ b/templates/ansible-log-parser-rules.txt.j2
@@ -1,0 +1,5 @@
+error /ERROR! the playbook: .* could not be found/
+error /failed=[1-9]/
+error /unreachable=[1-9]/
+error /fatal:(?!.*\n.*...ignoring)/
+warning /changed=[1-9]/


### PR DESCRIPTION
This is a cherry-pick from ansible-env-swisstxt. Ansible log parser rules were applied into the galaxy_role instead of this repo.

[commit/2e2dbd1a5220d63759d903d1e6d2da6f8004230d](https://github.com/swisstxt/ansible-env-swisstxt/commit/2e2dbd1a5220d63759d903d1e6d2da6f8004230d#diff-3de147b18721bee5364cea0309be4c4dc82b219093a8f7a723668e404bf0c1bc)
[commit/ad350a6a00042c4f54bee761374658f735150e9c](https://github.com/swisstxt/ansible-env-swisstxt/commit/ad350a6a00042c4f54bee761374658f735150e9c#diff-3de147b18721bee5364cea0309be4c4dc82b219093a8f7a723668e404bf0c1bc)

Cheers,
Andi